### PR TITLE
Add phiv ident for U+03D5 GREEK PHI SYMBOL

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1243,6 +1243,11 @@
                 <math><mi>φ</mi></math>
               </dd>
 
+              <dt><code>phiv</code></dt>
+              <dd>
+                <math><mi>ϕ</mi></math>
+              </dd>
+
               <dt><code>pi</code></dt>
               <dd>
                 <math><mi>π</mi></math>

--- a/src/compiler/tokenizer/lexemes.mjs
+++ b/src/compiler/tokenizer/lexemes.mjs
@@ -151,6 +151,7 @@ export const KNOWN_IDENTS = new Map([
   ["omega", { value: "ω" }],
   ["oo", { value: "∞" }],
   ["phi", { value: "φ" }],
+  ["phiv", { value: "ϕ" }],
   ["pi", { value: "π" }],
   ["psi", { value: "ψ" }],
   ["rho", { value: "ρ" }],


### PR DESCRIPTION
Adds `phiv` identifier for ϕ (U+03D5 GREEK PHI SYMBOL) character.

This is `\phi` in TeX, but `&phiv;`, `&straightphi;` and `&varphi;` in HTML. Token `straightphi` is too long, and `\varphi` stands for `phi` (U+03C6) in mathup, so I’ve chosen `phiv` for consistency with existing tools and to prevent confusion.
