### PR TITLE
Add prefixes for common element attributes

### DIFF
--- a/src/compiler/parser/handlers/prefix.mjs
+++ b/src/compiler/parser/handlers/prefix.mjs
@@ -1,93 +1,156 @@
 import expr from "./expr.mjs";
 
+// XXX: I think that these attr functions belong in transforms.
+
+function attrTextContent({ type, items }) {
+  if (type !== "Term" || !items) {
+    return "";
+  }
+  if (items.length !== 1) {
+    return "";
+  }
+
+  const [{ type: itemType, value: itemValue }] = items;
+  if (!itemType || !itemValue) {
+    return "";
+  }
+
+  if (itemType === "NumberLiteral") {
+    return `#${itemValue}`;
+  }
+  if (itemType === "IdentLiteral" || itemType === "TextLiteral") {
+    return itemValue;
+  }
+
+  return "";
+}
+
+function attrSanitize(name, value) {
+  const colorAttrs = ["mathcolors", "mathbackground"];
+  if (colorAttrs.includes(name)) {
+    return attrSanitizeColor(name, value);
+  }
+  return [name, value];
+}
+
+function attrSanitizeColor(name, value) {
+  // See https://www.w3.org/TR/MathML3/chapter2.html#fund.color
+  if (value.startsWith("#")) {
+    const n = value.slice(1);
+    // Either #RGB or #RRGGBB.
+    if (n.length !== 3 && n.length !== 6) {
+      return [];
+    }
+    for (const c of n) {
+      // XXX: Perhaps I should stick to the eslint code style,
+      // but the no-continue rule is kinda weird.
+      /* eslint-disable no-continue */
+      if (c >= "0" && c <= "9") {
+        continue;
+      }
+      if (c >= "A" && c <= "F") {
+        continue;
+      }
+      if (c >= "a" && c <= "f") {
+        continue;
+      }
+      /* eslint-enable no-continue */
+      // Not a hex digit, remove this attribute.
+      return [];
+    }
+    return [name, value];
+  }
+  const htmlColors = [
+    "aqua",
+    "black",
+    "blue",
+    "fuchsia",
+    "gray",
+    "green",
+    "lime",
+    "maroon",
+    "navy",
+    "olive",
+    "purple",
+    "red",
+    "silver",
+    "teal",
+    "white",
+    "yellow",
+  ];
+  if (htmlColors.includes(value.toLowerCase())) {
+    return [name, value];
+  }
+  if (name === "mathbackground" && value === "transparent") {
+    return [name, value];
+  }
+  return [];
+}
+
 export default function prefix({ start, tokens }) {
   const token = tokens[start];
-  let next = expr({ stack: [], start: start + 1, tokens });
 
-  if (next && next.node && next.node.type === "SpaceLiteral") {
+  let next = expr({ stack: [], start: start + 1, tokens });
+  if (next.node.type === "SpaceLiteral") {
     next = expr({ stack: [], start: next.end, tokens });
   }
 
-  // XXX: Arity > 2 not implemented.
-  if (token.arity === 2) {
-    if (
-      next &&
-      next.node &&
-      next.node.type === "FencedGroup" &&
-      next.node.items.length === 2
-    ) {
-      let items = next.node.items.map((col) =>
-        col.length === 1 ? col[0] : { type: "Term", items: col },
-      );
-
-      if (token.name === "root") {
-        items = items.reverse();
-      }
-
-      return {
-        node: {
-          type: "BinaryOperation",
-          name: token.name,
-          attrs: token.attrs,
-          items,
-        },
-        end: next.end,
-      };
-    }
-
-    const first = next;
-    let second = next && expr({ stack: [], start: next.end, tokens });
-
-    if (second && second.node && second.node.type === "SpaceLiteral") {
-      second = expr({ stack: [], start: second.end, tokens });
-    }
-
-    const items =
-      token.name === "root"
-        ? [second.node, first.node]
-        : [first.node, second.node];
-
-    return {
-      node: {
-        type: "BinaryOperation",
-        name: token.name,
-        attrs: token.attrs,
-        items,
-      },
-      end: second.end,
-    };
+  let { arity } = token;
+  if (!arity) {
+    arity = 1;
   }
 
-  if (
-    next &&
-    next.node &&
-    next.node.type === "FencedGroup" &&
-    next.node.items.length === 1
-  ) {
+  let items;
+  if (next.node.type === "FencedGroup" && next.node.items.length === arity) {
     // The operant is not a matrix.
-    const items = next.node.items.map((col) =>
+    items = next.node.items.map((col) =>
       col.length === 1 ? col[0] : { type: "Term", items: col },
     );
+  } else {
+    items = [next.node];
+    for (let i = 1; i < arity; i += 1) {
+      next = expr({ stack: [], start: next.end, tokens });
+      if (next.node.type === "SpaceLiteral") {
+        next = expr({ stack: [], start: next.end, tokens });
+      }
+      items.push(next.node);
+    }
+  }
+  if (token.name === "root") {
+    items = items.reverse();
+  }
 
-    return {
-      node: {
-        type: "UnaryOperation",
-        name: token.name,
-        accent: token.accent,
-        attrs: token.attrs,
-        items,
-      },
-      end: next.end,
-    };
+  let type = "BinaryOperation";
+  if (arity === 1) {
+    type = "UnaryOperation";
+  }
+
+  let { attrs } = token;
+  if (token.attrName) {
+    // Keep this as BinaryOperation even though it’s not,
+    // because UnaryOperation transformation *recursively*
+    // applies style attributes to child nodes.
+
+    const [valueNode, ...rest] = items;
+    items = rest;
+
+    let name = token.attrName;
+    let value = attrTextContent(valueNode);
+    [name, value] = attrSanitize(name, value);
+
+    if (name && value) {
+      attrs = { ...attrs };
+      attrs[name] = value;
+    }
   }
 
   return {
     node: {
-      type: "UnaryOperation",
+      type,
       name: token.name,
       accent: token.accent,
-      attrs: token.attrs,
-      items: [next.node],
+      attrs,
+      items,
     },
     end: next.end,
   };

--- a/src/compiler/tokenizer/lexemes.mjs
+++ b/src/compiler/tokenizer/lexemes.mjs
@@ -166,6 +166,27 @@ export const KNOWN_IDENTS = new Map([
   ["upsilon", { value: "υ" }],
   ["xi", { value: "ξ" }],
   ["zeta", { value: "ζ" }],
+
+  // Colors
+  // We also set attrs so that users will have a preview when
+  // they are used as standalone identifiers.
+  ["aqua", { value: "aqua", attrs: { mathcolor: "aqua" } }],
+  ["black", { value: "black", attrs: { mathcolor: "black" } }],
+  ["blue", { value: "blue", attrs: { mathcolor: "blue" } }],
+  ["fuchsia", { value: "fuchsia", attrs: { mathcolor: "fuchsia" } }],
+  ["gray", { value: "gray", attrs: { mathcolor: "gray" } }],
+  ["green", { value: "green", attrs: { mathcolor: "green" } }],
+  ["lime", { value: "lime", attrs: { mathcolor: "lime" } }],
+  ["maroon", { value: "maroon", attrs: { mathcolor: "maroon" } }],
+  ["navy", { value: "navy", attrs: { mathcolor: "navy" } }],
+  ["olive", { value: "olive", attrs: { mathcolor: "olive" } }],
+  ["purple", { value: "purple", attrs: { mathcolor: "purple" } }],
+  ["red", { value: "red", attrs: { mathcolor: "red" } }],
+  ["silver", { value: "silver", attrs: { mathcolor: "silver" } }],
+  ["teal", { value: "teal", attrs: { mathcolor: "teal" } }],
+  ["white", { value: "white", attrs: { mathcolor: "white" } }],
+  ["yellow", { value: "yellow", attrs: { mathcolor: "yellow" } }],
+  ["transparent", { value: "transparent" }],
 ]);
 
 export const KNOWN_OPS = new Map([
@@ -328,4 +349,10 @@ export const KNOWN_PREFIX = new Map([
   // Roots
   ["root", { name: "root", arity: 2 }],
   ["sqrt", { name: "sqrt" }],
+
+  // Attributes
+  ["id", { name: "style", attrName: "id", arity: 2 }],
+  ["href", { name: "style", attrName: "href", arity: 2 }],
+  ["color", { name: "style", attrName: "mathcolor", arity: 2 }],
+  ["background", { name: "style", attrName: "mathbackground", arity: 2 }],
 ]);


### PR DESCRIPTION
This is a draft of the `color` command feature.

### Overview

```
f(x) = color(red, cancel(a)) sin(x)
```

#### Changes

- New `color`, `background`, `id` and `href` commands for adding respective attributes.
- New idents for HTML4 colors (as specified by MathML).
- The code for `prefix` handler now works with `arity > 2`.

#### To-do

- Test cases and docs.
- Move attributes sanitization and color value evaluation to transforms.
  Also adds unnecessary noise to the `prefix.mjs` diff.
- Perhaps merge `unaryOperation` and regular `operation` transforms and let all ”{Unary,Binary,Ternary}Operations” be simply an “Operation”.
- Maybe keep both argument nodes visible on “error” instead of just removing the node with color/id/link value.


Closes #40
