### PR TITLE
Drop minimist in favor of util.parseArgs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "mathup",
       "version": "1.0.0-beta.6",
       "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.8"
-      },
       "bin": {
         "mathup": "bin/mathup.js"
       },
@@ -5713,6 +5710,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }

--- a/package.json
+++ b/package.json
@@ -89,8 +89,5 @@
     "prettier": "3.0.3",
     "rollup": "^4.3.0",
     "typescript": "^5.2.2"
-  },
-  "dependencies": {
-    "minimist": "^1.2.8"
   }
 }


### PR DESCRIPTION
Also refactor the cli utility.

**CLI Changes**

- The double dash between args and positionals is no longer required, though still recommended.
- Now we handle every positional as input as opposed to only the first. This means you can omit quoting the input However repeated whitespace is not perserved this way, so quoting is still recommended.

**Breaking Changes**

- CLI will now fail with a message on unrecognized option.